### PR TITLE
Use `unsignedBigIntegers` on the friendships id and fix the coding standard.

### DIFF
--- a/migrations/0000_00_00_000000_create_friendships_groups_table.stub.php
+++ b/migrations/0000_00_00_000000_create_friendships_groups_table.stub.php
@@ -14,9 +14,9 @@ class CreateFriendshipsGroupsTable extends Migration
     public function up()
     {
         Schema::create(config('friendships.tables.fr_groups_pivot'), function (Blueprint $table) {
-            $table->integer('friendship_id')->unsigned();
+            $table->unsignedBigInteger('friendship_id');
             $table->morphs('friend');
-            $table->integer('group_id')->unsigned();
+            $table->unsignedInteger('group_id');
             $table->foreign('friendship_id')
                 ->references('id')
                 ->on(config('friendships.tables.fr_pivot'))

--- a/migrations/0000_00_00_000000_create_friendships_groups_table.stub.php
+++ b/migrations/0000_00_00_000000_create_friendships_groups_table.stub.php
@@ -11,7 +11,8 @@ class CreateFriendshipsGroupsTable extends Migration
      *
      * @return void
      */
-    public function up() {
+    public function up()
+    {
         Schema::create(config('friendships.tables.fr_groups_pivot'), function (Blueprint $table) {
             $table->integer('friendship_id')->unsigned();
             $table->morphs('friend');
@@ -29,7 +30,8 @@ class CreateFriendshipsGroupsTable extends Migration
      *
      * @return void
      */
-    public function down() {
+    public function down()
+    {
         Schema::dropIfExists(config('friendships.tables.fr_groups_pivot'));
     }
 }

--- a/migrations/0000_00_00_000000_create_friendships_table.stub.php
+++ b/migrations/0000_00_00_000000_create_friendships_table.stub.php
@@ -14,7 +14,7 @@ class CreateFriendshipsTable extends Migration
     public function up()
     {
         Schema::create(config('friendships.tables.fr_pivot'), function (Blueprint $table) {
-            $table->bigIncrements('id')
+            $table->bigIncrements('id');
             $table->morphs('sender');
             $table->morphs('recipient');
             $table->tinyInteger('status')->default(0);

--- a/migrations/0000_00_00_000000_create_friendships_table.stub.php
+++ b/migrations/0000_00_00_000000_create_friendships_table.stub.php
@@ -14,7 +14,7 @@ class CreateFriendshipsTable extends Migration
     public function up()
     {
         Schema::create(config('friendships.tables.fr_pivot'), function (Blueprint $table) {
-            $table->increments('id');
+            $table->bigIncrements('id')
             $table->morphs('sender');
             $table->morphs('recipient');
             $table->tinyInteger('status')->default(0);

--- a/migrations/0000_00_00_000000_create_friendships_table.stub.php
+++ b/migrations/0000_00_00_000000_create_friendships_table.stub.php
@@ -11,8 +11,8 @@ class CreateFriendshipsTable extends Migration
      *
      * @return void
      */
-    public function up() {
-
+    public function up()
+    {
         Schema::create(config('friendships.tables.fr_pivot'), function (Blueprint $table) {
             $table->increments('id');
             $table->morphs('sender');
@@ -20,7 +20,6 @@ class CreateFriendshipsTable extends Migration
             $table->tinyInteger('status')->default(0);
             $table->timestamps();
         });
-
     }
 
     /**
@@ -28,7 +27,8 @@ class CreateFriendshipsTable extends Migration
      *
      * @return void
      */
-    public function down() {
+    public function down()
+    {
         Schema::dropIfExists(config('friendships.tables.fr_pivot'));
     }
 }


### PR DESCRIPTION
- Fix Coding Standard
- Changed the friendships id to a big unsigned integer.
- Changed the group id to an unsigned integer using Laravel's built in `unisgnedInteger();`